### PR TITLE
The package doesn't work without explicitly importing the isset module.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+const isset = require('isset');
+
 function Cookies($){
 	this.__proto__.header = [];
 	this.__proto__.signal = $;

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "url": "http://github.com/adamhalasz/diet-cookies/issues",
     "email": "mail@adamhalasz.com"
   },
+  "dependencies": {
+    "isset": "^1.0.2"
+  },
   "license": "MIT",
   "author": {
     "name": "Halász Ádám",


### PR DESCRIPTION
Setting cookies throws `ReferenceError: isset is not defined`. I figured that's because the [isset](https://www.npmjs.com/package/isset) module isn't explicitly installed and imported. I'm adding it to the list of dependencies, and added an import in `index.js`.
